### PR TITLE
Update readme.md to add exemple for Lua API and show .toggle()

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,16 @@ PeepsightEnable
 PeepsightDisable
 ```
 
+Alternatively you can start **Peepsight** with the `Lua` API:
+
+```lua
+local peepsight = require("peepsight")
+
+peepsight.enable()
+peepsight.disable()
+peepsight.toggle()
+```
+
 ## Grammers
 
 - [TypeScript Grammer](https://github.com/tree-sitter/tree-sitter-typescript/blob/master/common/define-grammar.js)


### PR DESCRIPTION
Hello, first I would like to thank you for this neovim plugin, I really like this feature and so far Peepsight was the best plugin to do that.

I was struggling because I needed to toggle instead of Enable/Disable and the readme.md, but I saw the function exist in `lua/peepsight/init.lua`.

It's why I added it to the readme.

I basically copy how they did on https://github.com/folke/zen-mode.nvim?tab=readme-ov-file#-usage and update it.